### PR TITLE
Annotation features (round 2)

### DIFF
--- a/webapp/templates/annotation_page.html
+++ b/webapp/templates/annotation_page.html
@@ -69,13 +69,184 @@
             letter-spacing: 2pt;
             font-weight: bold;
         }
+
+        #keymapOverlay {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: rgba(0, 0, 0, 0.5);
+            z-index: 100;
+        }
+
+        .hidden {
+            display: none;
+        }
+
+        kbd {
+            font-family: 'Courier New', Courier, monospace;
+            display: inline-block;
+            padding: 0.2em 0.8em;
+            font-size: 90%;
+            color: #444;
+            vertical-align: middle;
+            background-color: #f7f7f9;
+            border: 2px solid #cfcfcf;
+            border-bottom-color: #bbb;
+            border-radius: 3px;
+            box-shadow: inset 0 -1px 0 #bbb;
+        }
     </style>
 </head>
 
 <body>
+    <div id="keymapOverlay" class="hidden">
+        <div style="background: #fefefecc; max-width: 40em; margin: auto; padding: 2em;">
+            <h2>Keys</h2>
+            <div id="keymap-list"></div>
+        </div>
+    </div>
     <script src="https://cdn.jsdelivr.net/npm/p5@1.4.1/lib/p5.js"></script>
     <script>
-        const IMG_WIDTH = 512;
+
+        const KEY_MAP = {
+            zScrollUp: {
+                keyCode: 188,
+                key: ',',
+
+                description: 'Scroll up in z', shift: false, ctrl: false, alt: false
+            },
+            zScrollDown: {
+                keyCode: 190,
+                key: '.',
+
+                description: 'Scroll down in z', shift: false, ctrl: false, alt: false
+            },
+
+            panUp: {
+                keyCode: 38,
+                key: 'ArrowUp',
+
+                description: 'Pan up', shift: false, ctrl: false, alt: false
+            },
+            panUpFast: {
+                keyCode: 38,
+                key: 'ArrowUp',
+                description: '(Fast) Pan up', shift: true, ctrl: false, alt: false
+            },
+            panDown: {
+                keyCode: 40,
+                key: 'ArrowDown',
+                description: 'Pan down', shift: false, ctrl: false, alt: false
+            },
+            panDownFast: {
+                keyCode: 40,
+                key: 'ArrowDown',
+                description: '(Fast) Pan down', shift: true, ctrl: false, alt: false
+            },
+            panLeft: {
+                keyCode: 37,
+                key: 'ArrowLeft',
+                description: 'Pan left', shift: false, ctrl: false, alt: false
+            },
+            panLeftFast: {
+                keyCode: 37,
+                key: 'ArrowLeft',
+                description: '(Fast) Pan left', shift: true, ctrl: false, alt: false
+            },
+            panRight: {
+                keyCode: 39,
+                key: 'ArrowRight',
+                description: 'Pan right', shift: false, ctrl: false, alt: false
+            },
+            panRightFast: {
+                keyCode: 39,
+                key: 'ArrowRight',
+                description: '(Fast) Pan right', shift: true, ctrl: false, alt: false
+            },
+
+            zoomIn: {
+                keyCode: 61,
+                key: "+",
+                description: 'Zoom in', shift: false, ctrl: false, alt: false
+            },
+            zoomInFast: {
+                keyCode: 61,
+                key: "+",
+                description: '(Fast) Zoom in', shift: true, ctrl: false, alt: false
+            },
+            zoomOut: {
+                keyCode: 173,
+                key: "-",
+                description: 'Zoom out', shift: false, ctrl: false, alt: false
+            },
+            zoomOutFast: {
+                keyCode: 173,
+                key: "-",
+                description: '(Fast) Zoom out', shift: true, ctrl: false, alt: false
+            },
+
+            brushSizeUp: {
+                keyCode: 87,
+                key: "w",
+                description: 'Increase brush size', shift: false, ctrl: false, alt: false
+            },
+            brushSizeUpFast: {
+                keyCode: 87,
+                key: "w",
+                description: '(Fast) Increase brush size', shift: true, ctrl: false, alt: false
+            },
+            brushSizeDown: {
+                keyCode: 81,
+                key: "q",
+                description: 'Decrease brush size', shift: false, ctrl: false, alt: false
+            },
+            brushSizeDownFast: {
+                keyCode: 81,
+                key: "q",
+                description: '(Fast) Decrease brush size', shift: true, ctrl: false, alt: false
+            },
+
+            imageTransparencyUp: {
+                keyCode: 83,
+                key: "w",
+                description: 'Increase annotation transparency', shift: false, ctrl: false, alt:
+                    false
+            },
+            imageTransparencyUpFast: {
+                keyCode: 83,
+                key: "w",
+                description: '(Fast) Increase annotation transparency', shift: true, ctrl:
+                    false, alt: false
+            },
+            imageTransparencyDown: {
+                keyCode: 65,
+                key: "a",
+                description: 'Decrease annotation transparency', shift: false, ctrl: false, alt:
+                    false
+            },
+            imageTransparencyDownFast: {
+                keyCode: 65,
+                key: "a",
+                description: '(Fast) Decrease annotation transparency', shift: true, ctrl:
+                    false, alt: false
+            },
+
+            toggleAnnotationVisibility: {
+                keyCode: 86,
+                key: "v",
+                description: 'Toggle annotation visibility', shift: false, ctrl: false, alt:
+                    false
+            },
+
+            toggleKeyMapOverlay: {
+                keyCode: 191,
+                key: "?",
+                description: 'Toggle key map overlay', shift: false, ctrl: false, alt: false
+            },
+        };
+
         let STATE = {
             // Image Rendering:
             imageLoaded: false,
@@ -299,7 +470,8 @@
             }
 
             // Pressing V toggles annotation visibility:
-            if (keyCode === 86) {
+            // if (keyCode === 86) {
+            if (key === "v") {
                 STATE.annosVisible = !STATE.annosVisible;
             }
 
@@ -323,7 +495,7 @@
             }
 
             // Pan with arrows:
-            if (keyCode === UP_ARROW) {
+            if (key === 'ArrowUp') {
                 STATE.panY += keyIsDown(SHIFT)
                     ? CONFIG.pan.bigIncrement
                     : CONFIG.pan.smallIncrement;
@@ -390,6 +562,10 @@
                 }
             }
 
+            // ? toggles the key map:
+            if (keyCode === 191) {
+                toggleKeyMapOverlay();
+            }
         }
 
         function boundZoom() {
@@ -411,8 +587,17 @@
             boundZoom();
         }
 
-        function draw() {
+        function doubleClicked() {
+            // Check for mouse pos in histogram:
+            if (mouseX < CONFIG.histogram.width && mouseY < CONFIG.histogram.height) {
+                // reset histogram:
+                STATE.histogram.vmax = 1;
+                STATE.histogram.vmin = 0;
+                reloadHistogramSettings();
+            }
+        }
 
+        function draw() {
             // If window.prediction is set, load it into paintPixels.
             if (window.prediction) {
                 loadImage('data:image/png;base64,' + window.prediction, img => {
@@ -424,6 +609,7 @@
                     paintPixels.image(img, 0, 0, img.width / 2, img.width / 2);
                 });
                 window.prediction = undefined;
+                reloadHistogramSettings();
             }
 
             push();
@@ -455,10 +641,9 @@
             if (STATE.annosVisible) {
                 imgcoords = screenToImage(mouseX, mouseY);
                 if (paintPixels) {
+                    let homeSlice = STATE.z.current == STATE.z.annotating;
                     tint(
-                        STATE.z.current == STATE.z.annotating ? 255 : 128,
-                        STATE.z.current == STATE.z.annotating ? 255 : 0,
-                        STATE.z.current == STATE.z.annotating ? 255 : 128,
+                        homeSlice ? 255 : 128,
                         STATE.imageTransparency * 255);
                     image(paintPixels, 0, 0, paintPixels.width * 2 * STATE.zoom, paintPixels.height * 2 * STATE.zoom);
                 }
@@ -625,6 +810,39 @@
                 }
             }
         }
+
+        // Toggle keymap with ?:
+        function toggleKeyMapOverlay() {
+            let overlay = document.getElementById("keymapOverlay");
+            if (overlay.classList.contains("hidden")) {
+                overlay.classList.remove("hidden");
+            } else {
+                overlay.classList.add("hidden");
+            }
+        }
+
+        // Create the keymap list:
+        (() => {
+            let keymapList = document.getElementById("keymap-list");
+            // Create the table:
+            let table = document.createElement("table");
+            keymapList.appendChild(table);
+            let keymap = KEY_MAP;
+            for (let key in keymap) {
+                // Convert from keyCode to character:
+                let k = keymap[key].key;
+                // Ascii to character:
+                let keymapItem = document.createElement("tr");
+                keymapItem.innerHTML = `<td>
+                ${keymap[key].shift ? "<kbd>⇧</kbd>" : ""}
+                ${keymap[key].option ? "<kbd>⌥</kbd>" : ""}
+                ${keymap[key].control ? "<kbd>⌃</kbd>" : ""}
+                ${keymap[key].command ? "<kbd>⌘</kbd>" : ""}</td><td>
+                <kbd>${k}</kbd></td><td>${keymap[key].description} <small>(${key})</small></td>
+                `;
+                table.appendChild(keymapItem);
+            }
+        })()
     </script>
 
     <!-- UI to submit (floating bottom) -->


### PR DESCRIPTION
 - [x] Shift+Escape returns you to the home slice at the default position
 - [x] You can only paint on the center slice
 - [x] Off-center slices show annotation but it's tinted
 - [x] Prepare for dynamic user-defined keymap
 - [x] Double-click histogram to reset
 - [x] <kbd>?</kbd> to show the keymap