### PR TITLE
feat(ui): Disallow retraining with fewer than 2 annotations

### DIFF
--- a/webapp/templates/job_page.html
+++ b/webapp/templates/job_page.html
@@ -114,11 +114,12 @@
                 <p>
                     There are currently {{ num_annotations }} annotated slices. You can train a model with
                     any
-                    number of annotated slices, but we recommend at least 10. (You
-                    can always annotate a bit more and then retrain!)
+                    number of annotated slices, but we recommend at least 10.
                 </p>
-                <p><a target="_blank" href="{{ url_for('annotation_page', job_id=job.id) }}">Continue
-                        annotating</a>
+                <p>
+                    <a target="_blank" href="{{ url_for('annotation_page', job_id=job.id) }}">
+                        Continue annotating
+                    </a>
                 </p>
                 {% endif %}
             </div>

--- a/webapp/templates/job_page_components/annotation_cta.html
+++ b/webapp/templates/job_page_components/annotation_cta.html
@@ -29,11 +29,13 @@
         <button id="segmentation-trigger-button" onclick="triggerSegmentation()">Start automatic segmentation</button>
         {% endif %}
     </p>
+    {% if num_annotations >= 2 %}
     <p>
         If you would like to refresh the realtime segmentation that you're shown in the annotation tool but you <i>do
             not yet want to generate segmentation</i>, you can click to <a href="#" id="train-only-trigger-button"
             onclick="triggerTrainOnly()">retrain
             the model</a>.
     </p>
+    {% endif %}
     {% endif %}
 </article>


### PR DESCRIPTION
There's no reason for us to spend compute on extremely low-quality segmentation anyway, and this obviates the need to reshape training dataset vectors.

Closes #19.